### PR TITLE
Jakarta Upgrade for Jersey 3 and Tomcat 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.gusdb</groupId>
   <artifactId>base-pom</artifactId>
-  <version>2.9-SNAPSHOT</version>
+  <version>2.8-jakarta</version>
   <packaging>pom</packaging>
 
   <licenses>
@@ -28,7 +28,7 @@
 
   <scm>
     <developerConnection>scm:git:ssh://github.com/VEuPathDB/base-pom</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.8-jakarta</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.gusdb</groupId>
   <artifactId>base-pom</artifactId>
-  <version>2.8-jakarta</version>
+  <version>2.9-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <licenses>
@@ -28,7 +28,7 @@
 
   <scm>
     <developerConnection>scm:git:ssh://github.com/VEuPathDB/base-pom</developerConnection>
-    <tag>v2.8-jakarta</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,11 @@
             <groupId>com.github.fge</groupId>
             <artifactId>msg-simple</artifactId>
           </exclusion>
+          <!-- Included version 1.4.3 has runtime conflicts with 1.4.7 -->
+          <exclusion>
+            <groupId>javax.mail</groupId>
+            <artifactId>mailapi</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>11</java.version>
-    <jersey.version>2.35</jersey.version>
+    <jersey.version>3.0.4</jersey.version>
     <jackson.version>2.12.2</jackson.version>
     <oltu.version>1.0.0</oltu.version>
   </properties>
@@ -383,11 +383,6 @@
       </dependency>
 
       <!-- JAX-RS / RESTful Web Services -->
-      <dependency>
-        <groupId>javax.ws.rs</groupId>
-        <artifactId>javax.ws.rs-api</artifactId>
-        <version>2.0</version>
-      </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.core</groupId>
         <artifactId>jersey-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.gusdb</groupId>
   <artifactId>base-pom</artifactId>
-  <version>2.10-SNAPSHOT</version>
+  <version>2.9-jakarta</version>
   <packaging>pom</packaging>
 
   <licenses>
@@ -28,7 +28,7 @@
 
   <scm>
     <developerConnection>scm:git:ssh://github.com/VEuPathDB/base-pom</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.9-jakarta</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.gusdb</groupId>
   <artifactId>base-pom</artifactId>
-  <version>2.9-jakarta</version>
+  <version>2.10-jakarta-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <licenses>
@@ -28,7 +28,7 @@
 
   <scm>
     <developerConnection>scm:git:ssh://github.com/VEuPathDB/base-pom</developerConnection>
-    <tag>v2.9-jakarta</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
This will be a long-lived branch until we can get all our code onto the new Servlet 5 spec (move from javax to jakarta namespace), which includes getting our websites onto Tomcat 10 or an equivalent.  It should not be merged until that occurs, but should be kept up to date with the dependencies and patterns in main so the eventual convergence will have minimal code impacts.